### PR TITLE
Get the highest quality video file available

### DIFF
--- a/vigram_vine.js
+++ b/vigram_vine.js
@@ -66,7 +66,7 @@ function getChannelsVigramButton(container, url, name)
 
 function getMeta(content)
 {
-    var pattern = 'twitter:player:stream" content="',
+    var pattern = '<video src="',
         start = content.indexOf(pattern, 0) + pattern.length,
         end = content.indexOf('>', start, 200) - 1,
         url = content.substring(start, end).split('?')[0],


### PR DESCRIPTION
Example: https://vine.co/v/eVe7T3pDJ7i

"twitter:player:stream" gets
https://v.cdn.vine.co/r/videos_h264high/820FC708601269036475434319872_4fca6b65764.2.0.6707393379861648700.mp4
(480x480), while "video src" gets
https://v.cdn.vine.co/r/videos/820FC708601269036475434319872_4fca6b65764.2.0.6707393379861648700.mp4
(720x720).
"video src" gets higher bit rate video file as well as higher resolution
(when available).